### PR TITLE
fix: handle unhandled promise rejections with proper error

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -257,7 +257,11 @@ window.addEventListener('error', (event) => {
 });
 
 window.addEventListener('unhandledrejection', (event) => {
-  ErrorHandler.handleUnexpectedError(new Error(event.reason), {
+  const error = event.reason instanceof Error
+    ? event.reason
+    : new Error(String(event.reason));
+
+  ErrorHandler.handleUnexpectedError(error, {
     type: 'unhandledrejection',
     reason: event.reason,
   });


### PR DESCRIPTION
## Summary
- ensure unhandled promise rejections are logged with proper Error instances

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689a640aa2a883309340e584891d66c6